### PR TITLE
V1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LAIIQAToolbox
-### v1.1
+### v1.1.1
 
 
 ## Descripción

--- a/laiiqatoolbox.m
+++ b/laiiqatoolbox.m
@@ -196,7 +196,7 @@ classdef laiiqatoolbox < handle
                         var(1) = residual;
                         var(2) = consumed;
                         var(3) = total;
-                        if contains(obj.legend,'default')
+                        if isequal(obj.legend,{'default'})
                             disp("Para " + obj.defaultlegend{i} + ":");
                         else
                             disp("Para " + obj.legend{i} + ":");


### PR DESCRIPTION
Corregido error de ` contains()` en `ozonecalc`, línea 199, cambiado por `isequal()`
